### PR TITLE
csexec-cbmc: start cbmc in sane environment

### DIFF
--- a/cbmc_utils/csexec-cbmc.sh
+++ b/cbmc_utils/csexec-cbmc.sh
@@ -44,6 +44,9 @@ fi
 # (only debug purpose)
 # echo "Executing cbmc ${CBMC_ARGS[*]} ${ARGV[0]}" 1> /dev/tty 2>&1
 # Verify
-timeout --signal=KILL $TIMEOUT cbmc "${CBMC_ARGS[@]}"  "${ARGV[0]}" 2> "$LOGDIR/pid-$$.err" > "$LOGDIR/pid-$$.out"
+/usr/bin/env -i /usr/bin/bash -lc 'exec "$@"' cbmc \
+    /usr/bin/timeout --signal=KILL $TIMEOUT \
+    /usr/bin/cbmc "${CBMC_ARGS[@]}" "${ARGV[0]}" \
+    2> "$LOGDIR/pid-$$.err" > "$LOGDIR/pid-$$.out"
 
-exec $(csexec --print-ld-exec-cmd) "${ARGV[@]}"
+exec $(/usr/bin/csexec --print-ld-exec-cmd) "${ARGV[@]}"

--- a/cbmc_utils/csexec-cbmc.sh
+++ b/cbmc_utils/csexec-cbmc.sh
@@ -49,4 +49,4 @@ fi
     /usr/bin/cbmc "${CBMC_ARGS[@]}" "${ARGV[0]}" \
     2> "$LOGDIR/pid-$$.err" > "$LOGDIR/pid-$$.out"
 
-exec $(/usr/bin/csexec --print-ld-exec-cmd) "${ARGV[@]}"
+exec $(/usr/bin/csexec --print-ld-exec-cmd ${CSEXEC_ARGV0}) "${ARGV[@]}"


### PR DESCRIPTION
csexec-cbmc is transparently invoked from test programs that often
run in specially crafted environment to exercise the tested binaries.
For example, GNU coreutils sets $PATH such that the just built binaries
are preferred over system-provided binaries with the same name.  This
causes havoc in case cbmc wants to use system-provided binaries
without specifying them with absolute path.  Especially, when cbmc
by mistake invokes binaries that use csexec-loader as ELF interpreter,
this recursively invokes csexec-cbmc and cbmc in a loop and attacks
the machine with a fork bomb.