### PR TITLE
csexec-cbmc: do the output coversion immediately

### DIFF
--- a/cbmc_utils/csexec-cbmc.sh
+++ b/cbmc_utils/csexec-cbmc.sh
@@ -58,7 +58,8 @@ then
             /usr/bin/timeout --signal=KILL $TIMEOUT \
             /usr/bin/cbmc --unwind 1 --verbosity 4 --json-ui \
             "${CBMC_ARGS[@]}"  "${ARGV[0]}" \
-            2> "$LOGDIR/pid-$$.err" > "$LOGDIR/pid-$$.out"
+            2> "$LOGDIR/pid-$$.err" | /usr/bin/tee "$LOGDIR/pid-$$.out" | \
+            cbmc-convert-output > "$LOGDIR/pid-$$.out.conv"
 else
         /usr/bin/goto-instrument "${GOTO_INSTRUMENT_ARGS[@]}" \
         "${ARGV[0]}" "${ARGV[0]}.instrumented.$$" \
@@ -68,7 +69,8 @@ else
             /usr/bin/timeout --signal=KILL $TIMEOUT \
             /usr/bin/cbmc --unwind 1 --verbosity 4 --json-ui \
             "${CBMC_ARGS[@]}"  "${ARGV[0]}.instrumented.$$" \
-            2> "$LOGDIR/pid-$$.err" > "$LOGDIR/pid-$$.out"
+            2> "$LOGDIR/pid-$$.err" | /usr/bin/tee "$LOGDIR/pid-$$.out" | \
+            cbmc-convert-output > "$LOGDIR/pid-$$.out.conv"
 fi
 
 exec $(/usr/bin/csexec --print-ld-exec-cmd ${CSEXEC_ARGV0}) "${ARGV[@]}"


### PR DESCRIPTION
This is change relevant to https://github.com/aufover/rpm-symbiotic/commit/429cdc4b1aa6dd5bc1f2a1b75bfd05baf7bd65d6 and https://github.com/csutils/csmock/commit/e7c003f1cf7f497bb0e452612e121cdd35c26ab6.